### PR TITLE
Add header + Remove unsafe usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -237,14 +237,8 @@ impl PipeTo for Command {
 
         let mut child = self.spawn()?;
 
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or(io::ErrorKind::BrokenPipe)?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or(io::ErrorKind::BrokenPipe)?;
+        let stdout = child.stdout.take().ok_or(io::ErrorKind::BrokenPipe)?;
+        let stderr = child.stderr.take().ok_or(io::ErrorKind::BrokenPipe)?;
 
         *self = Command::new(out[0]);
         self.args(&out[1..]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,37 +226,6 @@ impl Drop for Wait {
     }
 }
 
-// TODO: Any other targets that need a different implementation.
-#[cfg(not(target_os = "windows"))]
-unsafe fn create_stdios(child: &Child) -> (Stdio, Stdio) {
-    use std::os::unix::io::{AsRawFd, FromRawFd};
-    let stdout = Stdio::from_raw_fd(child.stdout.as_ref().map(AsRawFd::as_raw_fd).unwrap());
-    let stderr = Stdio::from_raw_fd(child.stderr.as_ref().map(AsRawFd::as_raw_fd).unwrap());
-
-    (stdout, stderr)
-}
-
-#[cfg(target_os = "windows")]
-unsafe fn create_stdios(child: &Child) -> (Stdio, Stdio) {
-    use std::os::windows::io::{AsRawHandle, FromRawHandle};
-    let stdout = Stdio::from_raw_handle(
-        child
-            .stdout
-            .as_ref()
-            .map(AsRawHandle::as_raw_handle)
-            .unwrap(),
-    );
-    let stderr = Stdio::from_raw_handle(
-        child
-            .stderr
-            .as_ref()
-            .map(AsRawHandle::as_raw_handle)
-            .unwrap(),
-    );
-
-    (stdout, stderr)
-}
-
 trait PipeTo {
     fn pipe_to(&mut self, out: &[&OsStr], err: &[&OsStr]) -> io::Result<Wait>;
 }
@@ -266,9 +235,16 @@ impl PipeTo for Command {
         self.stdout(Stdio::piped());
         self.stderr(Stdio::piped());
 
-        let child = self.spawn()?;
+        let mut child = self.spawn()?;
 
-        let (stdout, stderr) = unsafe { create_stdios(&child) };
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(io::ErrorKind::BrokenPipe)?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or(io::ErrorKind::BrokenPipe)?;
 
         *self = Command::new(out[0]);
         self.args(&out[1..]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,10 +174,11 @@ fn count_lines(content: String, sort_order: SortOrder) {
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
+    let _ = writeln!(handle, "  Lines Copies  Function name");
     for row in data {
         let _ = writeln!(
             handle,
-            "{:7} {:4}  {}",
+            "{:7} {:6}  {}",
             row.1.total_lines, row.1.copies, row.0
         );
     }


### PR DESCRIPTION
I've added header to output, so the columns are hopefully more obvious:
```
  Lines Copies  Function name
   3062    173  core::ptr::real_drop_in_place
    966      2  alloc::slice::merge_sort
    812      2  alloc::raw_vec::RawVec<T,A>::reserve_internal
    612      2  alloc::slice::insert_head
    586      1  cargo_llvm_lines::read_llvm_ir
```
I've also noticed one unsafe function, which I don't understand why is it needed. I replaced it with hopefully correct, safe code. I tested it only on Windows, so if it's wrong/breaks on Linux, I can remove the commit.

Edit: Forgot about rustfmt.