### PR TITLE
do not execute llvm optimizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,7 @@ where
 
     args.push("--".into());
     args.push("--emit=llvm-ir".into());
+    args.push("-Cno-prepopulate-passes".into());
     args.push("-o".into());
     args.push(outfile.into());
     args.extend(it);


### PR DESCRIPTION
* see how many llvm-lines rustc sends to llvm and
not the result after all optimizations in llvm
* faster compile time

closes https://github.com/dtolnay/cargo-llvm-lines/issues/3