### PR TITLE
Fix things up so `cargo llvm-lines` can be used in `rustc-perf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Install with `cargo install cargo-llvm-lines`.
 
 ## Output
 
-One line per function with five columns of output:
+One line per function with three columns of output:
 
 1. Total number of lines of LLVM IR generated across all instantiations of the
    function (and the percentage of the total).
-2. Number of instantiations of the function. For a generic function, roughly the
-   number of distinct combinations of generic type parameters it is called with
-   (and the percentage of the total).
+2. Number of instantiations of the function (and the percentage of the total).
+   For a generic function, roughly the number of distinct combinations of
+   generic type parameters it is called with.
 3. Name of the function.
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,13 +26,7 @@ enum Opt {
         #[structopt(long, hidden = true)]
         filter_cargo: bool,
 
-        #[structopt(long, hidden = true)]
-        lib: bool,
-
-        #[structopt(long, hidden = true)]
-        bin: Option<String>,
-
-        /// Set the sort order to number of instantiations
+        /// Set the sort order to number of instantiations.
         #[structopt(
             short,
             long,
@@ -41,6 +35,26 @@ enum Opt {
             default_value = "lines",
         )]
         sort: SortOrder,
+
+        // All these options are passed through to the `rustc` invocation.
+        #[structopt(long, hidden = true)]
+        all_features: bool,
+        #[structopt(long, hidden = true)]
+        bin: Option<String>,
+        #[structopt(long, hidden = true)]
+        features: Option<String>,
+        #[structopt(long, hidden = true)]
+        lib: bool,
+        #[structopt(long, hidden = true)]
+        manifest_path: Option<String>,
+        #[structopt(long, hidden = true)]
+        no_default_features: bool,
+        #[structopt(short, long, hidden = true)]
+        package: Option<String>,
+        #[structopt(long, hidden = true)]
+        profile: Option<String>,
+        #[structopt(long, hidden = true)]
+        release: bool,
     },
 }
 
@@ -79,6 +93,8 @@ fn cargo_llvm_lines(filter_cargo: bool, sort_order: SortOrder) -> io::Result<i32
 
 fn run_cargo_rustc(outfile: PathBuf) -> io::Result<()> {
     let mut cmd = Command::new("cargo");
+
+    // Strip out options that are for cargo-llvm-lines itself.
     let args: Vec<_> = env::args_os()
         .filter(|s| {
             !["--sort", "-s", "lines", "Lines", "copies", "Copies"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,9 +330,19 @@ where
         args.push(format!("--color={}", setting).into());
     }
 
+    // The `-Cno-prepopulate-passes` means we skip LLVM optimizations, which is
+    // good because (a) we count the LLVM IR lines are sent to LLVM, not how
+    // many there are after optimizations run, and (b) it's faster.
+    //
+    // The `-Cpasses=name-anon-globals` follows on: it's required to avoid the
+    // following error on some programs: "The current compilation is going to
+    // use thin LTO buffers without running LLVM's NameAnonGlobals pass. This
+    // will likely cause errors in LLVM. Consider adding -C
+    // passes=name-anon-globals to the compiler command line."
     args.push("--".into());
     args.push("--emit=llvm-ir".into());
     args.push("-Cno-prepopulate-passes".into());
+    args.push("-Cpasses=name-anon-globals".into());
     args.push("-o".into());
     args.push(outfile.into());
     args.extend(it);


### PR DESCRIPTION
In https://github.com/rust-lang/rustc-perf/pull/663 I have added support for `cargo llvm-lines` in `rustc-perf`. This PR contains the fixes I had to make to get it working on all the benchmarks.