### PR TITLE
Eliminate pipe to cat

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn run_cargo_rustc(outfile: PathBuf) -> io::Result<()> {
         let spawn = errcmd.spawn()?;
         Wait(vec![spawn, child])
     };
-    cmd.status().map(|status| status.code().unwrap_or(1))?;
+    cmd.status()?;
     drop(_wait);
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,19 +90,7 @@ fn cargo_llvm_lines(filter_cargo: bool, sort_order: SortOrder) -> io::Result<i32
     let outdir = TempDir::new("cargo-llvm-lines").expect("failed to create tmp file");
     let outfile = outdir.path().join("crate");
 
-    if let Err(err) = run_cargo_rustc(outfile) {
-        if cfg!(windows) {
-            // Running on Windows tends to fail with "System cannot find the
-            // file specified. (os error 2)" even when the original command
-            // succeeded and the output IR has been written to the outfile. Just
-            // log the error and try to read IR anyway. Let read_llvm_ir fail in
-            // the case that something really went wrong.
-            eprintln!("Unsuccessful `cargo rustc` invocation: {}", err);
-        } else {
-            return Err(err);
-        }
-    }
-
+    run_cargo_rustc(outfile)?;
     let ir = read_llvm_ir(outdir)?;
     count_lines(ir, sort_order);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,21 +132,15 @@ fn run_cargo_rustc(outfile: PathBuf) -> io::Result<()> {
     filter_cargo.extend(args.iter().map(OsString::as_os_str));
     filter_cargo.insert(2, OsStr::new("--filter-cargo"));
 
-    // Filter stdout through `cat` (i.e. do nothing with it), and filter stderr
-    // through a second invocation of `cargo-llvm-lines`, but with
+    // Filter stderr through a second invocation of `cargo-llvm-lines` that has
     // `--filter-cargo` specified so that it just does the filtering in
     // `filter_err()` above.
     let _wait = {
-        cmd.stdout(Stdio::piped());
+        cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::piped());
 
         let mut child = cmd.spawn()?;
-
-        let stdout = child.stdout.take().ok_or(io::ErrorKind::BrokenPipe)?;
         let stderr = child.stderr.take().ok_or(io::ErrorKind::BrokenPipe)?;
-
-        cmd = Command::new("cat");
-        cmd.stdin(stdout);
 
         let mut errcmd = Command::new(filter_cargo[0]);
         errcmd.args(&filter_cargo[1..]);
@@ -156,7 +150,6 @@ fn run_cargo_rustc(outfile: PathBuf) -> io::Result<()> {
         let spawn = errcmd.spawn()?;
         Wait(vec![spawn, child])
     };
-    cmd.status()?;
     drop(_wait);
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn run_cargo_rustc(outfile: PathBuf) -> io::Result<()> {
         let spawn = errcmd.spawn()?;
         Wait(vec![spawn, child])
     };
-    run(cmd)?;
+    cmd.status().map(|status| status.code().unwrap_or(1))?;
     drop(_wait);
 
     Ok(())
@@ -308,10 +308,6 @@ fn has_hash(name: &str) -> bool {
 
 fn is_ascii_hexdigit(byte: u8) -> bool {
     byte >= b'0' && byte <= b'9' || byte >= b'a' && byte <= b'f'
-}
-
-fn run(mut cmd: Command) -> io::Result<i32> {
-    cmd.status().map(|status| status.code().unwrap_or(1))
 }
 
 struct Wait(Vec<Child>);


### PR DESCRIPTION
This child process handling was lifted from the 2017 implementation of `cargo expand`...

Closes #26.