### PR TITLE
Forward --target flag to rustc

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,8 @@ enum Opt {
         features: Option<String>,
         #[structopt(long)]
         all_features: bool,
+        #[structopt(long, value_name = "TRIPLE")]
+        target: Option<String>,
         #[structopt(long)]
         no_default_features: bool,
         #[structopt(long, value_name = "PATH")]


### PR DESCRIPTION
Closes #29.

Tested by adding `#[cfg(target_arch = "wasm32")] compile_error!("wasm32");` to main.rs and confirming that `cargo run -- llvm-lines --target wasm32-unknown-unknown` does trip it.