### PR TITLE
Added a --files option to analyse rustc's --emit=llvm-lines output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rustc-demangle = "0.1"
 tempdir = "0.3"
 structopt = "0.3.8"
 clap = { version = "2.32.0", features = ["wrap_help"] }
+glob = "0.3.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Since you can't use cargo-llvm-lines with x.py, I added a `--files` option, so that I could measure the llvm-lines of rustc itself.

I'm also writing [an entry](https://github.com/rust-lang/rustc-dev-guide/pull/905) in rustc-dev-guide. Example usage:
```
RUSTFLAGS="--emit=llvm-ir" ./x.py build --stage 0 compiler/rustc

# Single crate, eg. rustc_middle
cargo llvm-lines --files ./build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/debug/deps/rustc_middle* > llvm-lines-middle.txt
# Whole compiler at once
cargo llvm-lines --files ./build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/debug/deps/*.ll > llvm-lines.txt
```

I successfully used this in rust-lang/rust#76680.