### PR TITLE
feat: Allow running against examples

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,0 +1,7 @@
+fn test() {
+    eprintln!("Test");
+}
+
+fn main() {
+    test();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,8 @@ enum Opt {
         lib: bool,
         #[structopt(long, value_name = "BIN")]
         bin: Option<String>,
+        #[structopt(long, value_name = "example")]
+        example: Option<String>,
         #[structopt(long)]
         release: bool,
         #[structopt(long, value_name = "PROFILE-NAME")]


### PR DESCRIPTION
When running against a library which uses generics in its API it is
often useful to run llvm-lines against its examples to force the
instantiation and thereby generation of llvm IR.