### PR TITLE
Suppress unused field warnings on Opt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ OPTIONS:
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "cargo-llvm-lines", bin_name = "cargo")]
+#[allow(dead_code)]
 enum Opt {
     #[structopt(
         name = "llvm-lines",


### PR DESCRIPTION
<details>
<summary>These fields are all relevant to the argument parser and forwarded through to the delegated <code>cargo rustc</code>.</summary>

```console
warning: field is never read: `quiet`
  --> src/main.rs:82:9
   |
82 |         quiet: bool,
   |         ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field is never read: `package`
  --> src/main.rs:84:9
   |
84 |         package: Option<String>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `lib`
  --> src/main.rs:86:9
   |
86 |         lib: bool,
   |         ^^^^^^^^^

warning: field is never read: `bin`
  --> src/main.rs:88:9
   |
88 |         bin: Option<String>,
   |         ^^^^^^^^^^^^^^^^^^^

warning: field is never read: `example`
  --> src/main.rs:90:9
   |
90 |         example: Option<String>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `release`
  --> src/main.rs:92:9
   |
92 |         release: bool,
   |         ^^^^^^^^^^^^^

warning: field is never read: `profile`
  --> src/main.rs:94:9
   |
94 |         profile: Option<String>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `features`
  --> src/main.rs:96:9
   |
96 |         features: Option<String>,
   |         ^^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `all_features`
  --> src/main.rs:98:9
   |
98 |         all_features: bool,
   |         ^^^^^^^^^^^^^^^^^^

warning: field is never read: `no_default_features`
   --> src/main.rs:100:9
    |
100 |         no_default_features: bool,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `target`
   --> src/main.rs:102:9
    |
102 |         target: Option<String>,
    |         ^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `manifest_path`
   --> src/main.rs:104:9
    |
104 |         manifest_path: Option<String>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: field is never read: `rest`
   --> src/main.rs:108:9
    |
108 |         rest: Vec<OsString>,
    |         ^^^^^^^^^^^^^^^^^^^
```
</details>