### PR TITLE
Add subcommand metadata so `cargo --list` can print a description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,17 @@ name = "cargo-llvm-lines"
 version = "0.4.14"
 dependencies = [
  "atty",
+ "cargo-subcommand-metadata",
  "clap",
  "rustc-demangle",
  "tempdir",
 ]
+
+[[package]]
+name = "cargo-subcommand-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
 
 [[package]]
 name = "clap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 atty = "0.2"
+cargo-subcommand-metadata = "0.1"
 clap = { version = "3.1", features = ["derive", "wrap_help"] }
 rustc-demangle = "0.1"
 tempdir = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,10 @@ use std::process::{self, Command, Stdio};
 use std::str::FromStr;
 use tempdir::TempDir;
 
+cargo_subcommand_metadata::description!(
+    "Count the number of lines of LLVM IR across all instantiations of a generic function"
+);
+
 const ABOUT: &str = "
 Print amount of lines of LLVM IR that is generated for the current project.
 


### PR DESCRIPTION
- https://github.com/rust-lang/cargo/issues/10662
- https://github.com/rust-lang/cargo/pull/10663