### PR TITLE
feat: add --filter to filter functions shown in output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +35,7 @@ dependencies = [
  "atty",
  "cargo-subcommand-metadata",
  "clap",
+ "regex",
  "rustc-demangle",
  "tempdir",
 ]
@@ -141,6 +151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +246,23 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/dtolnay/cargo-llvm-lines"
 atty = "0.2"
 cargo-subcommand-metadata = "0.1"
 clap = { version = "4", features = ["deprecated", "derive", "wrap_help"] }
+regex = "1.7.0"
 rustc-demangle = "0.1"
 tempdir = "0.3"
 


### PR DESCRIPTION
I use this tool regularly, thanks for publishing it!

While using it, I often need to use things like `cargo llvm-lines | rg my_crate::module::` to filter
the output and avoid being drowned by things I'm not (yet) trying to improve.

The default of the previous solution is that it strips the header and will still pipe the entire
output to `rg` when only 10% of it are useful to me.

This adds a dependency on `regex`, and using the tool itself:

```
cg r --release -- llvm-lines --filter regex
  Finished release [optimized] target(s) in 0.06s
   Running `/Users/alexis/.local/cache/cargo_target_dir/release/cargo-llvm-lines llvm-lines --filter regex`
 Compiling cargo-llvm-lines v0.4.19 (/Users/alexis/repos/tp/cargo-llvm-lines)
  Finished dev [unoptimized + debuginfo] target(s) in 0.73s
Lines                Copies              Function name
-----                ------              -------------
51076                1225                (TOTAL)
   28 (0.1%,  0.1%)     1 (0.1%,  0.1%)  core::ptr::drop_in_place<regex::exec::Exec>
   11 (0.0%,  0.1%)     1 (0.1%,  0.2%)  core::ptr::drop_in_place<core::option::Option<regex::re_unicode::Regex>>
    6 (0.0%,  0.1%)     1 (0.1%,  0.2%)  core::ptr::drop_in_place<regex::re_unicode::Regex>
```