### PR TITLE
Case sensitive `--sort`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,6 @@ enum Opt {
             long,
             value_enum,
             value_name = "ORDER",
-            ignore_case = true,
             default_value_t = SortOrder::Lines,
         )]
         sort: SortOrder,
@@ -214,7 +213,7 @@ fn run_cargo_rustc(outfile: &Path) -> io::Result<i32> {
                 prev_was_filter = false;
                 return false;
             }
-            !["--sort", "-s", "lines", "Lines", "copies", "Copies"].contains(&x.as_ref())
+            !["--sort", "-s", "lines", "copies"].contains(&x.as_ref())
         })
         .collect();
     cmd.args(&wrap_args(args.clone(), outfile));


### PR DESCRIPTION
This dates back to #10 which added `case_insensitive = "true"`, later converted to `case_insensitive = true` by d56c232f49b2527b2c9138b56544bab61d9c148f and `ignore_case = true` by 6384ced9821bf563aa8cfc993445334f3432aadb. The 2018 code must have been from before structopt had sane handling of case in enums -- probably without it structopt would have required `--sort Lines`/`Copies`. These days clap applies a `rename_all = "lower"` by default in derived ValueEnum impls.