### PR TITLE
Switch from atty crate to is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,17 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,9 +61,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "cargo-llvm-lines"
 version = "0.4.25"
 dependencies = [
- "atty",
  "cargo-subcommand-metadata",
  "clap",
+ "is-terminal",
  "regex",
  "rustc-demangle",
  "tempfile",
@@ -205,15 +194,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -233,7 +213,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -244,7 +224,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256017f749ab3117e93acb91063009e1f1bb56d03965b14c2c8df4eb02c524d8"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "io-lifetimes",
  "rustix 0.37.6",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cargo-llvm-lines"
 
 [dependencies]
-atty = "0.2"
 cargo-subcommand-metadata = "0.1"
 clap = { version = "4", features = ["deprecated", "derive", "wrap_help"] }
+is-terminal = "0.4"
 regex = "1.7.0"
 rustc-demangle = "0.1"
 tempfile = "3.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ mod table;
 
 use crate::count::{count_lines, Instantiations};
 use crate::opts::{Coloring, LlvmLines, SortOrder, Subcommand};
-use atty::Stream::Stderr;
 use clap::{CommandFactory, Parser};
+use is_terminal::IsTerminal;
 use regex::Regex;
 use std::collections::HashMap as Map;
 use std::env;
@@ -218,7 +218,7 @@ fn propagate_opts(cmd: &mut Command, opts: &LlvmLines, outfile: &Path) {
         Some(Coloring::Always) => "always",
         Some(Coloring::Never) => "never",
         None | Some(Coloring::Auto) => {
-            if env::var_os("NO_COLOR").is_none() && atty::is(Stderr) {
+            if env::var_os("NO_COLOR").is_none() && io::stderr().is_terminal() {
                 "always"
             } else {
                 "never"


### PR DESCRIPTION
`atty` is unmaintained. Cargo and numerous other projects have switched to `is-terminal`.