### PR TITLE
feat: `--bench` support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,7 @@ fn propagate_opts(cmd: &mut Command, opts: &LlvmLines, outfile: &Path) {
         ref bin,
         ref example,
         ref test,
+        ref bench,
         release,
         ref profile,
         ref features,
@@ -189,6 +190,11 @@ fn propagate_opts(cmd: &mut Command, opts: &LlvmLines, outfile: &Path) {
     if let Some(test) = test {
         cmd.arg("--test");
         cmd.arg(test);
+    }
+
+    if let Some(bench) = bench {
+        cmd.arg("--bench");
+        cmd.arg(bench);
     }
 
     if release {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -76,6 +76,8 @@ pub struct LlvmLines {
     pub example: Option<String>,
     #[arg(long, value_name = "NAME")]
     pub test: Option<String>,
+    #[arg(long, value_name = "NAME")]
+    pub bench: Option<String>,
     #[arg(long)]
     pub release: bool,
     #[arg(long, value_name = "PROFILE-NAME")]


### PR DESCRIPTION
Support measuring lines for benchmarks similar to binaries and examples. This is the same argument that `cargo build` supports.