### PR TITLE
feat: Allow sorting output by name.

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -117,6 +117,7 @@ pub struct LlvmLines {
 pub enum SortOrder {
     Lines,
     Copies,
+    Name,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]

--- a/src/table.rs
+++ b/src/table.rs
@@ -35,6 +35,11 @@ pub(crate) fn print(
                 key_lo.cmp(&key_hi)
             });
         }
+        SortOrder::Name => data.sort_by(|a, b| {
+            let key_lo = (&a.0, b.1.copies, b.1.total_lines);
+            let key_hi = (&b.0, a.1.copies, b.1.total_lines);
+            key_lo.cmp(&key_hi)
+        }),
     }
 
     let lines_width = total.total_lines.to_string().len();


### PR DESCRIPTION
Sometimes it is useful to diff two distinct llvm-lines invocations (e.g. with and without `-Z share-generics`), where having the output be sorted by name can be quite useful.