### PR TITLE
Fix crate name in help template

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -10,7 +10,7 @@ Options shown below without an explanation mean the same thing as the
 corresponding option of `cargo build`.";
 
 const TEMPLATE: &str = "\
-{bin} {version}
+cargo-llvm-lines {version}
 {author}
 {about}
 


### PR DESCRIPTION
`cargo llvm-lines --help`
Before: "llvm-lines 0.4.34"
After: "cargo-llvm-lines 0.4.34"