### PR TITLE
Add short features flag

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -101,7 +101,7 @@ pub struct LlvmLines {
     pub bench: Option<String>,
 
     // Feature selection
-    #[arg(long, value_name = "FEATURES", help_heading = FEATURE_SELECTION)]
+    #[arg(short = 'F', long, value_name = "FEATURES", help_heading = FEATURE_SELECTION)]
     pub features: Option<String>,
     #[arg(long, help_heading = FEATURE_SELECTION)]
     pub all_features: bool,


### PR DESCRIPTION
Cargo added a short flag `-F` for `--features` in https://github.com/rust-lang/cargo/pull/10576.